### PR TITLE
feat: allow manual positioning of flowchart nodes

### DIFF
--- a/docs/config/setup/mermaid/interfaces/LayoutData.md
+++ b/docs/config/setup/mermaid/interfaces/LayoutData.md
@@ -10,7 +10,7 @@
 
 # Interface: LayoutData
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:168](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L168)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:169](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L169)
 
 ## Indexable
 
@@ -22,7 +22,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:168](https://github.co
 
 > **config**: [`MermaidConfig`](MermaidConfig.md)
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:171](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L171)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:172](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L172)
 
 ---
 
@@ -30,7 +30,7 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:171](https://github.co
 
 > **edges**: `Edge`\[]
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:170](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L170)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:171](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L171)
 
 ---
 
@@ -38,4 +38,4 @@ Defined in: [packages/mermaid/src/rendering-util/types.ts:170](https://github.co
 
 > **nodes**: `Node`\[]
 
-Defined in: [packages/mermaid/src/rendering-util/types.ts:169](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L169)
+Defined in: [packages/mermaid/src/rendering-util/types.ts:170](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/rendering-util/types.ts#L170)

--- a/docs/config/setup/mermaid/interfaces/ParseOptions.md
+++ b/docs/config/setup/mermaid/interfaces/ParseOptions.md
@@ -10,7 +10,7 @@
 
 # Interface: ParseOptions
 
-Defined in: [packages/mermaid/src/types.ts:88](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L88)
+Defined in: [packages/mermaid/src/types.ts:94](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L94)
 
 ## Properties
 
@@ -18,7 +18,7 @@ Defined in: [packages/mermaid/src/types.ts:88](https://github.com/mermaid-js/mer
 
 > `optional` **suppressErrors**: `boolean`
 
-Defined in: [packages/mermaid/src/types.ts:93](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L93)
+Defined in: [packages/mermaid/src/types.ts:99](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L99)
 
 If `true`, parse will return `false` instead of throwing error when the diagram is invalid.
 The `parseError` function will not be called.

--- a/docs/config/setup/mermaid/interfaces/ParseResult.md
+++ b/docs/config/setup/mermaid/interfaces/ParseResult.md
@@ -10,7 +10,7 @@
 
 # Interface: ParseResult
 
-Defined in: [packages/mermaid/src/types.ts:96](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L96)
+Defined in: [packages/mermaid/src/types.ts:102](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L102)
 
 ## Properties
 
@@ -18,7 +18,7 @@ Defined in: [packages/mermaid/src/types.ts:96](https://github.com/mermaid-js/mer
 
 > **config**: [`MermaidConfig`](MermaidConfig.md)
 
-Defined in: [packages/mermaid/src/types.ts:104](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L104)
+Defined in: [packages/mermaid/src/types.ts:110](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L110)
 
 The config passed as YAML frontmatter or directives
 
@@ -28,6 +28,6 @@ The config passed as YAML frontmatter or directives
 
 > **diagramType**: `string`
 
-Defined in: [packages/mermaid/src/types.ts:100](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L100)
+Defined in: [packages/mermaid/src/types.ts:106](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L106)
 
 The diagram type, e.g. 'flowchart', 'sequence', etc.

--- a/docs/config/setup/mermaid/interfaces/RenderResult.md
+++ b/docs/config/setup/mermaid/interfaces/RenderResult.md
@@ -10,7 +10,7 @@
 
 # Interface: RenderResult
 
-Defined in: [packages/mermaid/src/types.ts:114](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L114)
+Defined in: [packages/mermaid/src/types.ts:120](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L120)
 
 ## Properties
 
@@ -18,7 +18,7 @@ Defined in: [packages/mermaid/src/types.ts:114](https://github.com/mermaid-js/me
 
 > `optional` **bindFunctions**: (`element`) => `void`
 
-Defined in: [packages/mermaid/src/types.ts:132](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L132)
+Defined in: [packages/mermaid/src/types.ts:138](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L138)
 
 Bind function to be called after the svg has been inserted into the DOM.
 This is necessary for adding event listeners to the elements in the svg.
@@ -45,7 +45,7 @@ bindFunctions?.(div); // To call bindFunctions only if it's present.
 
 > **diagramType**: `string`
 
-Defined in: [packages/mermaid/src/types.ts:122](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L122)
+Defined in: [packages/mermaid/src/types.ts:128](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L128)
 
 The diagram type, e.g. 'flowchart', 'sequence', etc.
 
@@ -55,6 +55,6 @@ The diagram type, e.g. 'flowchart', 'sequence', etc.
 
 > **svg**: `string`
 
-Defined in: [packages/mermaid/src/types.ts:118](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L118)
+Defined in: [packages/mermaid/src/types.ts:124](https://github.com/mermaid-js/mermaid/blob/master/packages/mermaid/src/types.ts#L124)
 
 The svg code for the rendered graph.

--- a/docs/syntax/flowchart.md
+++ b/docs/syntax/flowchart.md
@@ -1003,6 +1003,32 @@ flowchart TD
   A@{ img: "https://mermaid.js.org/favicon.svg", label: "My example image label", pos: "t", h: 60, constraint: "on" }
 ```
 
+## Manual node positions (optional)
+
+Automatic layout keeps most diagrams tidy, but you can manually place specific nodes when you need precise positioning. Add a `position` field to the node metadata to provide coordinates in the diagram's coordinate system (x grows to the right, y grows downward).
+
+- Object form: `position: { x: 120, y: 40 }`
+- Array form: `position: [120, 40]`
+- String form: `position: "120, 40"`
+
+Only the nodes with a `position` specified are moved; all other nodes continue to use the automatic layout.
+
+```mermaid-example
+flowchart LR
+  Start@{ position: { x: 20, y: 60 } }
+  Process@{ position: [160, 60] }
+  Decision@{ position: "300 120" }
+  Start --> Process --> Decision
+```
+
+```mermaid
+flowchart LR
+  Start@{ position: { x: 20, y: 60 } }
+  Process@{ position: [160, 60] }
+  Decision@{ position: "300 120" }
+  Start --> Process --> Decision
+```
+
 ## Links between nodes
 
 Nodes can be connected with links/edges. It is possible to have different types of links or attach a text string to a link.

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts
@@ -164,6 +164,34 @@ describe('flow db getData', () => {
     expect(edges[2].curve).toBe('catmullRom');
     expect(edges[3].curve).toBe('stepBefore');
   });
+
+  it.each([
+    ['object', ' position: { x: 5, y: 10 } ', { x: 5, y: 10 }],
+    ['array', ' position: [15, 25] ', { x: 15, y: 25 }],
+    ['string', ' position: "35, 45" ', { x: 35, y: 45 }],
+  ])('should capture manual positions when provided as a %s', (_, metadata, expected) => {
+    flowDb.addVertex('A', { text: 'A', type: 'text' }, undefined, [], [], '', {}, metadata);
+
+    const { nodes } = flowDb.getData();
+    const node = nodes.find((item) => item.id === 'A');
+
+    expect(node?.manualPosition).toEqual(expected);
+  });
+
+  it('should throw for invalid manual positions', () => {
+    expect(() =>
+      flowDb.addVertex(
+        'A',
+        { text: 'A', type: 'text' },
+        undefined,
+        [],
+        [],
+        '',
+        {},
+        ' position: nope '
+      )
+    ).toThrowError(/Invalid position/);
+  });
 });
 
 describe('flow db direction', () => {

--- a/packages/mermaid/src/diagrams/flowchart/flowDb.ts
+++ b/packages/mermaid/src/diagrams/flowchart/flowDb.ts
@@ -5,7 +5,7 @@ import type { DiagramDB } from '../../diagram-api/types.js';
 import { log } from '../../logger.js';
 import { isValidShape, type ShapeID } from '../../rendering-util/rendering-elements/shapes.js';
 import type { Edge, Node } from '../../rendering-util/types.js';
-import type { EdgeMetaData, NodeMetaData } from '../../types.js';
+import type { EdgeMetaData, ManualPosition, NodeMetaData } from '../../types.js';
 import utils, { getEdgeId } from '../../utils.js';
 import common from '../common/common.js';
 import {
@@ -32,6 +32,74 @@ interface LinkData {
 }
 
 const MERMAID_DOM_ID_PREFIX = 'flowchart-';
+
+const parseCoordinate = (value: unknown, axis: 'x' | 'y', id: string): number => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length > 0) {
+      const parsed = Number(trimmed);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+
+  throw new Error(
+    `Invalid ${axis}-coordinate for node "${id}". Position values must be numbers and can be provided as strings.`
+  );
+};
+
+const parseManualPosition = (
+  position: NodeMetaData['position'],
+  id: string
+): ManualPosition | undefined => {
+  if (position === undefined || position === null) {
+    return undefined;
+  }
+
+  const createPosition = (xValue: unknown, yValue: unknown): ManualPosition => ({
+    x: parseCoordinate(xValue, 'x', id),
+    y: parseCoordinate(yValue, 'y', id),
+  });
+
+  if (Array.isArray(position)) {
+    if (position.length < 2) {
+      throw new Error(
+        `Invalid position for node "${id}". Arrays must contain at least two values representing x and y coordinates.`
+      );
+    }
+    return createPosition(position[0], position[1]);
+  }
+
+  if (typeof position === 'string') {
+    const parts = position
+      .split(/[\s,]+/)
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0);
+
+    if (parts.length < 2) {
+      throw new Error(
+        `Invalid position for node "${id}". Provide two numeric values separated by a comma or whitespace.`
+      );
+    }
+
+    return createPosition(parts[0], parts[1]);
+  }
+
+  if (typeof position === 'object' && !Array.isArray(position)) {
+    const maybeRecord = position as { x?: unknown; y?: unknown };
+    if ('x' in maybeRecord || 'y' in maybeRecord) {
+      return createPosition(maybeRecord.x, maybeRecord.y);
+    }
+  }
+
+  throw new Error(
+    `Invalid position for node "${id}". Use { x, y }, [x, y] or "x, y" to provide manual coordinates.`
+  );
+};
 
 // We are using arrow functions assigned to class instance fields instead of methods as they are required by flow JISON
 export class FlowDB implements DiagramDB {
@@ -220,6 +288,9 @@ export class FlowDB implements DiagramDB {
       }
       if (doc?.pos) {
         vertex.pos = doc?.pos;
+      }
+      if (doc?.position !== undefined) {
+        vertex.manualPosition = parseManualPosition(doc.position, id);
       }
       if (doc?.img) {
         vertex.img = doc?.img;
@@ -1030,6 +1101,7 @@ You have to call mermaid.initialize.`
         assetWidth: vertex.assetWidth,
         assetHeight: vertex.assetHeight,
         constraint: vertex.constraint,
+        manualPosition: vertex.manualPosition,
       };
       if (isGroup) {
         nodes.push({

--- a/packages/mermaid/src/diagrams/flowchart/types.ts
+++ b/packages/mermaid/src/diagrams/flowchart/types.ts
@@ -1,4 +1,5 @@
 import type { ShapeID } from '../../rendering-util/rendering-elements/shapes.js';
+import type { ManualPosition } from '../../types.js';
 
 /**
  * Valid `type` args to `yy.addVertex` taken from
@@ -45,6 +46,7 @@ export interface FlowVertex {
   defaultWidth?: number;
   imageAspectRatio?: number;
   constraint?: 'on' | 'off';
+  manualPosition?: ManualPosition;
 }
 
 export interface FlowText {

--- a/packages/mermaid/src/docs/syntax/flowchart.md
+++ b/packages/mermaid/src/docs/syntax/flowchart.md
@@ -602,6 +602,24 @@ flowchart TD
   A@{ img: "https://mermaid.js.org/favicon.svg", label: "My example image label", pos: "t", h: 60, constraint: "on" }
 ```
 
+## Manual node positions (optional)
+
+Automatic layout keeps most diagrams tidy, but you can manually place specific nodes when you need precise positioning. Add a `position` field to the node metadata to provide coordinates in the diagram's coordinate system (x grows to the right, y grows downward).
+
+- Object form: `position: { x: 120, y: 40 }`
+- Array form: `position: [120, 40]`
+- String form: `position: "120, 40"`
+
+Only the nodes with a `position` specified are moved; all other nodes continue to use the automatic layout.
+
+```mermaid-example
+flowchart LR
+  Start@{ position: { x: 20, y: 60 } }
+  Process@{ position: [160, 60] }
+  Decision@{ position: "300 120" }
+  Start --> Process --> Decision
+```
+
 ## Links between nodes
 
 Nodes can be connected with links/edges. It is possible to have different types of links or attach a text string to a link.

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.js
@@ -27,6 +27,71 @@ import { log } from '../../../logger.js';
 import { getSubGraphTitleMargins } from '../../../utils/subGraphTitleMargins.js';
 import { getConfig } from '../../../diagram-api/diagramAPI.js';
 
+const toFinite = (value) =>
+  typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+
+export const applyManualNodePositions = (graph) => {
+  const deltas = new Map();
+
+  graph.nodes().forEach((nodeId) => {
+    const node = graph.node(nodeId);
+    if (!node || node.isGroup || !node.manualPosition) {
+      return;
+    }
+
+    const targetX = toFinite(node.manualPosition.x);
+    const targetY = toFinite(node.manualPosition.y);
+
+    if (targetX === undefined || targetY === undefined) {
+      return;
+    }
+
+    const currentX = toFinite(node.x) ?? 0;
+    const currentY = toFinite(node.y) ?? 0;
+    const dx = targetX - currentX;
+    const dy = targetY - currentY;
+
+    node.x = targetX;
+    node.y = targetY;
+    deltas.set(nodeId, { dx, dy });
+  });
+
+  if (deltas.size === 0) {
+    return;
+  }
+
+  graph.edges().forEach((edgeObj) => {
+    const edge = graph.edge(edgeObj);
+    if (!edge) {
+      return;
+    }
+
+    const startDelta = deltas.get(edgeObj.v) ?? { dx: 0, dy: 0 };
+    const endDelta = deltas.get(edgeObj.w) ?? { dx: 0, dy: 0 };
+
+    if (Array.isArray(edge.points) && edge.points.length > 0) {
+      const lastIndex = edge.points.length - 1;
+      edge.points = edge.points.map((point, index) => {
+        const t = lastIndex === 0 ? 1 : index / lastIndex;
+        const dx = startDelta.dx * (1 - t) + endDelta.dx * t;
+        const dy = startDelta.dy * (1 - t) + endDelta.dy * t;
+        return {
+          ...point,
+          x: point.x + dx,
+          y: point.y + dy,
+        };
+      });
+    }
+
+    if (typeof edge.x === 'number' && Number.isFinite(edge.x)) {
+      edge.x += (startDelta.dx + endDelta.dx) / 2;
+    }
+    if (typeof edge.y === 'number' && Number.isFinite(edge.y)) {
+      edge.y += (startDelta.dy + endDelta.dy) / 2;
+    }
+  });
+};
+
 const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, siteConfig) => {
   log.warn('Graph in recursive render:XAX', graphlibJson.write(graph), parentCluster);
   const dir = graph.graph().rankdir;
@@ -163,6 +228,8 @@ const recursiveRender = async (_elem, graph, diagramType, id, parentCluster, sit
   log.info('############################################# XXX');
 
   dagreLayout(graph);
+
+  applyManualNodePositions(graph);
 
   log.info('Graph after layout:', JSON.stringify(graphlibJson.write(graph)));
   // Move the nodes to the correct place

--- a/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.ts
+++ b/packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.ts
@@ -1,0 +1,61 @@
+import * as graphlib from 'dagre-d3-es/src/graphlib/index.js';
+import { applyManualNodePositions } from './index.js';
+
+describe('applyManualNodePositions', () => {
+  it('moves manual nodes without affecting other nodes', () => {
+    const graph = new graphlib.Graph({ multigraph: true, compound: true });
+    graph.setGraph({});
+
+    graph.setNode('a', { x: 10, y: 10, manualPosition: { x: 100, y: 100 } });
+    graph.setNode('b', { x: 40, y: 60 });
+    graph.setEdge('a', 'b', {
+      points: [
+        { x: 10, y: 10 },
+        { x: 40, y: 60 },
+      ],
+      x: 25,
+      y: 35,
+    });
+
+    applyManualNodePositions(graph);
+
+    const nodeA = graph.node('a');
+    const nodeB = graph.node('b');
+    const edge = graph.edge('a', 'b', undefined);
+
+    expect(nodeA.x).toBe(100);
+    expect(nodeA.y).toBe(100);
+    expect(nodeB.x).toBe(40);
+    expect(nodeB.y).toBe(60);
+    expect(edge.points[0]).toEqual({ x: 100, y: 100 });
+    expect(edge.points[1]).toEqual({ x: 40, y: 60 });
+    expect(edge.x).toBe(70);
+    expect(edge.y).toBe(80);
+  });
+
+  it('interpolates edge points when both endpoints move', () => {
+    const graph = new graphlib.Graph({ multigraph: true, compound: true });
+    graph.setGraph({});
+
+    graph.setNode('start', { x: 10, y: 10, manualPosition: { x: 0, y: 0 } });
+    graph.setNode('end', { x: 40, y: 60, manualPosition: { x: 100, y: 80 } });
+    graph.setEdge('start', 'end', {
+      points: [
+        { x: 10, y: 10 },
+        { x: 20, y: 30 },
+        { x: 40, y: 60 },
+      ],
+      x: 30,
+      y: 40,
+    });
+
+    applyManualNodePositions(graph);
+
+    const edge = graph.edge('start', 'end', undefined);
+    expect(edge.points[0]).toEqual({ x: 0, y: 0 });
+    expect(edge.points[1]).toEqual({ x: 45, y: 35 });
+    expect(edge.points[2]).toEqual({ x: 100, y: 80 });
+    expect(edge.x).toBe(55);
+    expect(edge.y).toBe(45);
+  });
+});

--- a/packages/mermaid/src/rendering-util/types.ts
+++ b/packages/mermaid/src/rendering-util/types.ts
@@ -2,7 +2,7 @@ export type MarkdownWordType = 'normal' | 'strong' | 'em';
 import type { MermaidConfig } from '../config.type.js';
 import type { ClusterShapeID } from './rendering-elements/clusters.js';
 import type { ShapeID } from './rendering-elements/shapes.js';
-import type { Bounds, Point } from '../types.js';
+import type { Bounds, ManualPosition, Point } from '../types.js';
 export interface MarkdownWord {
   content: string;
   type: MarkdownWordType;
@@ -42,6 +42,7 @@ interface BaseNode {
   isGroup?: boolean;
   width?: number;
   height?: number;
+  manualPosition?: ManualPosition;
   // Specific properties for State Diagram nodes TODO remove and use generic properties
   intersect?: (point: any) => any;
   calcIntersect?: (bounds: Bounds, point: Point) => any;

--- a/packages/mermaid/src/types.ts
+++ b/packages/mermaid/src/types.ts
@@ -8,9 +8,15 @@ export interface NodeMetaData {
   w?: string;
   h?: string;
   constraint?: 'on' | 'off';
+  position?: ManualPosition | [unknown, unknown] | string;
   priority: 'Very High' | 'High' | 'Medium' | 'Low' | 'Very Low';
   assigned?: string;
   ticket?: string;
+}
+
+export interface ManualPosition {
+  x: number;
+  y: number;
 }
 
 export interface ParticipantMetaData {


### PR DESCRIPTION
## Summary
- add parsing for node `position` metadata and carry the coordinates through flowchart layout data
- adjust the dagre renderer to apply manual node positions and update connected edges after the automatic layout runs
- document the new syntax and cover it with unit tests

## Testing
- pnpm vitest --run packages/mermaid/src/diagrams/flowchart/flowDb.spec.ts packages/mermaid/src/rendering-util/layout-algorithms/dagre/index.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68c98f802be8832886773a8fc50f1baf